### PR TITLE
fix: align pages stats with exported public data

### DIFF
--- a/scripts/build_website_stats.py
+++ b/scripts/build_website_stats.py
@@ -6,9 +6,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 DBS = {
-    'network_security': ROOT / 'db' / 'network-security.db',
-    'system_vulnerabilities': ROOT / 'db' / 'system-vulnerabilities.db',
-    'system_troubleshooting': ROOT / 'db' / 'system-troubleshooting.db',
+    'network_security': [
+        ROOT / 'db' / 'netsec-windows.db',
+        ROOT / 'db' / 'netsec-linux.db',
+        ROOT / 'db' / 'netsec-macos.db',
+    ],
+    'system_vulnerabilities': [ROOT / 'db' / 'system-vulnerabilities.db'],
+    'system_troubleshooting': [ROOT / 'db' / 'system-troubleshooting.db'],
 }
 
 
@@ -21,12 +25,16 @@ def count_rows(db_path: Path) -> int:
     return value
 
 
+def count_rows_many(db_paths: list[Path]) -> int:
+    return sum(count_rows(path) for path in db_paths)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--output', required=True)
     args = parser.parse_args()
 
-    categories = {key: count_rows(path) for key, path in DBS.items()}
+    categories = {key: count_rows_many(paths) for key, paths in DBS.items()}
     payload = {
         'total_entries': sum(categories.values()),
         'categories': categories,

--- a/scripts/tests/test_build_website_stats.py
+++ b/scripts/tests/test_build_website_stats.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / 'scripts' / 'build_website_stats.py'
+EXPORT_SCRIPT = ROOT / 'scripts' / 'export_website_data.py'
 
 
 def test_build_website_stats_outputs_summary_payload(tmp_path: Path):
@@ -20,3 +21,30 @@ def test_build_website_stats_outputs_summary_payload(tmp_path: Path):
     assert 'network_security' in payload['categories']
     assert 'system_vulnerabilities' in payload['categories']
     assert 'system_troubleshooting' in payload['categories']
+
+
+def test_build_website_stats_matches_exported_public_counts(tmp_path: Path):
+    stats_file = tmp_path / 'stats.json'
+    export_dir = tmp_path / 'website-data'
+
+    stats_result = subprocess.run(
+        [sys.executable, str(SCRIPT), '--output', str(stats_file)],
+        capture_output=True,
+        text=True,
+    )
+    assert stats_result.returncode == 0, stats_result.stderr
+
+    export_result = subprocess.run(
+        [sys.executable, str(EXPORT_SCRIPT), '--output-dir', str(export_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert export_result.returncode == 0, export_result.stderr
+
+    stats = json.loads(stats_file.read_text(encoding='utf-8'))
+    categories = json.loads((export_dir / 'categories.json').read_text(encoding='utf-8'))
+    entries = json.loads((export_dir / 'entries.json').read_text(encoding='utf-8'))
+
+    exported_counts = {item['key'].replace('-', '_'): item['entry_count'] for item in categories}
+    assert stats['categories'] == exported_counts
+    assert stats['total_entries'] == len(entries)

--- a/scripts/tests/test_website_mixed_mode_links.py
+++ b/scripts/tests/test_website_mixed_mode_links.py
@@ -9,3 +9,19 @@ def test_website_mentions_markdown_and_sqlite_access_paths():
     assert 'Markdown' in home
     assert 'SQLite' in home
     assert 'markdown_path' in about or '原文' in about
+
+
+def test_home_uses_generated_stats_and_categories_instead_of_legacy_hardcoded_counts():
+    home = (ROOT / 'website' / 'src' / 'pages' / 'Home.tsx').read_text(encoding='utf-8')
+    assert 'loadStats' in home
+    assert 'loadCategories' in home
+    assert '3154' not in home
+    assert '452' not in home
+    assert '3000+' not in home
+
+
+def test_about_does_not_keep_legacy_entries_fallback():
+    about = (ROOT / 'website' / 'src' / 'pages' / 'About.tsx').read_text(encoding='utf-8')
+    assert 'loadStats' in about
+    assert 'entries: 3154' not in about
+    assert '3,154+' not in about

--- a/website/src/pages/About.tsx
+++ b/website/src/pages/About.tsx
@@ -329,7 +329,7 @@ export default function About() {
   const { t } = useTranslation();
 
   // Wire to generated static data stats
-  const [stats, setStats] = useState({ stars: 21, forks: 1, contributors: 3, commits: 63, entries: 3154 });
+  const [stats, setStats] = useState({ stars: 21, forks: 1, contributors: 3, commits: 63, entries: 0 });
   useEffect(() => {
     loadStats().then((s) => {
       if (s?.githubStars) setStats(prev => ({ ...prev, stars: s.githubStars }));
@@ -588,7 +588,7 @@ export default function About() {
           {/* Stats grid */}
           <div className="mb-12 grid grid-cols-2 gap-4 sm:grid-cols-4">
             <MetricCard icon={<RefreshCw className="h-5 w-5" />} value="Daily" label={t('about.statSync') as string} delay={0} />
-            <MetricCard icon={<Database className="h-5 w-5" />} value={stats.entries > 0 ? `${stats.entries.toLocaleString()}+` : '3,154+'} label={t('about.statEntries') as string} delay={0.1} />
+            <MetricCard icon={<Database className="h-5 w-5" />} value={stats.entries > 0 ? `${stats.entries.toLocaleString()}+` : '0+'} label={t('about.statEntries') as string} delay={0.1} />
             <MetricCard icon={<GitCommit className="h-5 w-5" />} value={String(stats.commits)} label={t('about.statCommits') as string} delay={0.2} />
             <MetricCard icon={<CheckCircle className="h-5 w-5" />} value="MIT" label={t('about.statLicense') as string} delay={0.3} />
           </div>

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -14,7 +14,7 @@ import {
   Star,
 } from 'lucide-react';
 import { useTranslation } from '@/i18n/LanguageContext';
-import { loadStats } from '@/lib/content';
+import { loadCategories, loadStats } from '@/lib/content';
 
 /* ------------------------------------------------------------------ */
 /*  Matrix Rain Canvas (isolated, memoized)                            */
@@ -249,11 +249,32 @@ export default function Home() {
   const heroRef = useRef<HTMLDivElement>(null);
 
   // Fetch live stats from generated static data
-  const [, setLiveEntryCount] = useState(3300);
+  const [liveStats, setLiveStats] = useState({
+    totalEntries: 0,
+    networkSecurity: 0,
+  });
   useEffect(() => {
-    loadStats().then((s) => {
-      if (s?.totalEntries) setLiveEntryCount(s.totalEntries);
-    }).catch(() => {});
+    loadStats()
+      .then((s) => {
+        setLiveStats({
+          totalEntries: s?.totalEntries ?? 0,
+          networkSecurity: s?.categories?.network_security ?? 0,
+        });
+      })
+      .catch(() => {});
+  }, []);
+
+  const [categoryCounts, setCategoryCounts] = useState<Record<string, number>>({});
+  useEffect(() => {
+    loadCategories()
+      .then((items) => {
+        if (Array.isArray(items)) {
+          setCategoryCounts(
+            Object.fromEntries(items.map((item: { key: string; entry_count: number }) => [item.key, item.entry_count])),
+          );
+        }
+      })
+      .catch(() => {});
   }, []);
   const statsRef = useRef<HTMLDivElement>(null);
   const categoriesRef = useRef<HTMLDivElement>(null);
@@ -285,14 +306,14 @@ export default function Home() {
 
   const subtitleText =
     lang === 'zh'
-      ? '3000+ 精选漏洞 · SQLite + Markdown · 每日从 NVD、Exploit-DB、GitHub 安全公告等更新'
+      ? '持续更新的安全漏洞与系统故障知识库 · SQLite + Markdown · 每日从 NVD、Exploit-DB、GitHub 安全公告等更新'
       : lang === 'fr'
-        ? "3000+ vulnérabilités sélectionnées · SQLite + Markdown · Mises à jour quotidiennes depuis NVD, Exploit-DB, GitHub Advisories, et plus"
+        ? 'Base de connaissances sécurité continuellement mise à jour · SQLite + Markdown · Mises à jour quotidiennes depuis NVD, Exploit-DB, GitHub Advisories, et plus'
         : lang === 'ja'
-          ? '3000+ 厳選脆弱性 · SQLite + Markdown · NVD、Exploit-DB、GitHub Advisories などから毎日更新'
+          ? '継続更新されるセキュリティ脆弱性・障害ナレッジベース · SQLite + Markdown · NVD、Exploit-DB、GitHub Advisories などから毎日更新'
           : lang === 'ko'
-            ? '3000+ 선별된 취약점 · SQLite + Markdown · NVD, Exploit-DB, GitHub Advisories 등에서 매일 업데이트'
-            : '3,000+ curated vulnerabilities · SQLite + Markdown · Daily updated from NVD, Exploit-DB, GitHub Advisories, and more';
+            ? '지속적으로 업데이트되는 보안 취약점 및 장애 지식 베이스 · SQLite + Markdown · NVD, Exploit-DB, GitHub Advisories 등에서 매일 업데이트'
+            : 'Continuously updated security vulnerability and troubleshooting knowledge base · SQLite + Markdown · Daily updated from NVD, Exploit-DB, GitHub Advisories, and more';
 
   const badgeText =
     lang === 'zh'
@@ -431,14 +452,14 @@ export default function Home() {
           >
             <StatItem
               icon={<Database className="h-5 w-5" />}
-              value={3154}
+              value={liveStats.totalEntries}
               label={t('hero.stats.totalEntries') as string}
               start={statsInView}
             />
             <div className="hidden h-10 w-px bg-border-subtle md:block" />
             <StatItem
               icon={<Shield className="h-5 w-5" />}
-              value={452}
+              value={liveStats.networkSecurity}
               label={t('hero.stats.networkSecurity') as string}
               start={statsInView}
             />
@@ -539,7 +560,7 @@ export default function Home() {
                   {t('categories.networkSecurity.description') as string}
                 </p>
                 <p className="mt-4 text-xs text-text-muted">
-                  452 {t('categories.networkSecurity.stats') as string}
+                  {(categoryCounts['network-security'] ?? liveStats.networkSecurity).toLocaleString()} {t('categories.networkSecurity.stats') as string}
                 </p>
                 <span className="mt-auto inline-flex items-center gap-1 pt-6 text-sm text-text-muted transition-colors group-hover:text-accent-blue">
                   {t('categories.networkSecurity.cta') as string}


### PR DESCRIPTION
## Summary
- align website stats.json with exported public counts for Pages
- replace legacy hard-coded Home/About entry counts with generated data wiring
- add regression checks for stats/export consistency and legacy hard-coded values

## Test Plan
- [x] pytest -q scripts/tests/test_build_website_stats.py scripts/tests/test_website_mixed_mode_links.py
- [x] cd website && npm run build
